### PR TITLE
function call: preliminary support for list result

### DIFF
--- a/src/caller.cpp
+++ b/src/caller.cpp
@@ -30,14 +30,14 @@ void set_julia_type(std::string name, void* type_address)
 
 #include "jlpolymake/generated/call_function_feed_argument.h"
 
-struct call_context {
-   using list = pm::perl::ListResult;
+struct context {
+   using list = std::optional<pm::perl::ListResult>;
    using scalar = pm::perl::PropertyValue;
 };
 
 // Visualization in polymake only works if the function is called and
 // then immediately released,i.e. not converted to a property value
-template<typename return_type>
+template<typename return_type=typename context::scalar>
 auto polymake_call_function(
     const std::string&                     function_name,
     const std::vector<std::string>&        template_vector,
@@ -52,7 +52,7 @@ auto polymake_call_function(
 
 // Visualization in polymake only works if the method is called and
 // then immediately released,i.e. not converted to a property value
-template<typename return_type>
+template<typename return_type=typename context::scalar>
 auto polymake_call_method(
     const std::string&                     function_name,
     pm::perl::BigObject             object,
@@ -68,15 +68,15 @@ auto polymake_call_method(
 void add_caller(jlcxx::Module& jlpolymake)
 {
     jlpolymake.method("internal_call_function",
-                      &polymake_call_function<typename call_context::scalar>);
+                      &polymake_call_function<>);
     jlpolymake.method("internal_call_function_list",
-                      &polymake_call_function<typename call_context::list>);
+                      &polymake_call_function<typename context::list>);
     jlpolymake.method("internal_call_function_void",
                       &polymake_call_function<void>);
     jlpolymake.method("internal_call_method",
-                      &polymake_call_method<typename call_context::scalar>);
+                      &polymake_call_method<>);
     jlpolymake.method("internal_call_method_list",
-                      &polymake_call_method<typename call_context::list>);
+                      &polymake_call_method<typename context::list>);
     jlpolymake.method("internal_call_method_void",
                       &polymake_call_method<void>);
     jlpolymake.method("set_julia_type", &set_julia_type);

--- a/src/type_arrays.cpp
+++ b/src/type_arrays.cpp
@@ -92,7 +92,7 @@ tparametric1 add_array(jlcxx::Module& jlpolymake)
         if (!l)
            throw std::runtime_error("ListResult can be unpacked only once.");
         pm::Array<std::string> arr;
-        l.value() >> pm::perl::unroll(arr);
+        *l >> pm::perl::unroll(arr);
         l.reset();
         return arr;
     });

--- a/src/type_arrays.cpp
+++ b/src/type_arrays.cpp
@@ -88,9 +88,12 @@ tparametric1 add_array(jlcxx::Module& jlpolymake)
     jlpolymake.method("to_array_string", [](const pm::perl::PropertyValue& pv) {
         return to_SmallObject<pm::Array<std::string>>(pv);
     });
-    jlpolymake.method("to_array_string",[](pm::perl::ListResult& l) {
+    jlpolymake.method("to_array_string",[](std::optional<pm::perl::ListResult>& l) {
+        if (!l)
+           throw std::runtime_error("ListResult can be unpacked only once.");
         pm::Array<std::string> arr;
-        l >> pm::perl::unroll(arr);
+        l.value() >> pm::perl::unroll(arr);
+        l.reset();
         return arr;
     });
 

--- a/src/type_arrays.cpp
+++ b/src/type_arrays.cpp
@@ -88,6 +88,12 @@ tparametric1 add_array(jlcxx::Module& jlpolymake)
     jlpolymake.method("to_array_string", [](const pm::perl::PropertyValue& pv) {
         return to_SmallObject<pm::Array<std::string>>(pv);
     });
+    jlpolymake.method("to_array_string",[](pm::perl::ListResult& l) {
+        pm::Array<std::string> arr;
+        l >> pm::perl::unroll(arr);
+        return arr;
+    });
+
     jlpolymake.method("to_array_array_int",
                     [](const pm::perl::PropertyValue& pv) {
                         return to_SmallObject<pm::Array<pm::Array<pm::Int>>>(pv);

--- a/src/type_bigobjects.cpp
+++ b/src/type_bigobjects.cpp
@@ -19,6 +19,7 @@ void add_bigobject(jlcxx::Module& jlpolymake)
 {
 
     jlpolymake.add_type<pm::perl::PropertyValue>("PropertyValue");
+    jlpolymake.add_type<pm::perl::ListResult>("ListResult");
     jlpolymake.add_type<pm::perl::OptionSet>("OptionSet");
 
     jlpolymake.method("option_set_take", option_set_take);

--- a/src/type_bigobjects.cpp
+++ b/src/type_bigobjects.cpp
@@ -19,7 +19,8 @@ void add_bigobject(jlcxx::Module& jlpolymake)
 {
 
     jlpolymake.add_type<pm::perl::PropertyValue>("PropertyValue");
-    jlpolymake.add_type<pm::perl::ListResult>("ListResult");
+    jlpolymake.add_type<pm::perl::ListResult>("ListResult_internal");
+    jlpolymake.add_type<std::optional<pm::perl::ListResult>>("ListResult");
     jlpolymake.add_type<pm::perl::OptionSet>("OptionSet");
 
     jlpolymake.method("option_set_take", option_set_take);

--- a/type_setup.pl
+++ b/type_setup.pl
@@ -7,6 +7,9 @@ use File::Path qw(make_path);
 
 my $type_tuples = [
         ["PropertyValue", "pm::perl::PropertyValue", "PropertyValue", undef],
+        # ListResult cannot be used like other scalar based types so this is
+        # commented on purpose, also as a reminder
+        # ["ListResult", "pm::perl::ListResult", "ListResult", undef],
         ["OptionSet", "pm::perl::OptionSet", "OptionSet", undef],
         ["BigObject", "pm::perl::BigObject", "BigObject", "to_bigobject"],
         ["Integer", "pm::Integer", "Integer", "to_integer"],


### PR DESCRIPTION
To allow perl-array return values, at least for some special cases. With conversion to `Array<String>`.  (@alexej-jordan hit this at least twice)

```julia
julia> m = Polymake.Matrix{Polymake.Rational}(c.FACETS);
julia> templ = CxxWrap.StdVector{CxxWrap.StdString}();

julia> lr = Polymake.internal_call_function_list("common::rows_labeled",templ,Any[m])
Polymake.ListResultAllocated(Ptr{Nothing} @0x000055b1a6a0f520)

julia> x = Polymake.to_array_string(lr)
pm::Array<std::basic_string<char, std::char_traits<char>, std::allocator<char> >>
0:1 1 0 0
 1:1 -1 0 0
 2:1 0 1 0
 3:1 0 -1 0
 4:1 0 0 1
 5:1 0 0 -1
```

But there is a catch: we can do the `to_array_string(lr)` only once, julia will segfault when we try this a second time because the contents of the `ListResult` will be removed during the first conversion (this type is rather fragile, it also cannot be copied). @kalmarek is there a way to deal with that on the julia side or should we come up with a way to hide that type from the julia side?