### PR TITLE
fix getting pkg id in nightly

### DIFF
--- a/.github/workflows/test-polymake.yml
+++ b/.github/workflows/test-polymake.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   test-polymake:
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.julia-version == 'nightly' }}
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]

--- a/.github/workflows/test-polymakejl-branch.yml
+++ b/.github/workflows/test-polymakejl-branch.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   test-polymakejl-branch:
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.julia-version == 'nightly' }}
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]

--- a/.github/workflows/test-polymakejl-release.yml
+++ b/.github/workflows/test-polymakejl-release.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   test-polymakejl-release:
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.julia-version == 'nightly' }}
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]

--- a/test-prepare.jl
+++ b/test-prepare.jl
@@ -24,10 +24,9 @@ run(`cmake \
 
 # add override
 open("$(joinpath(Pkg.depots1(),"artifacts","Overrides.toml"))", "a") do io
-    project = Base.active_project()
-    uuid = Base.project_deps_get(project, "libpolymake_julia_jll")
+    pkgid = Base.identify_package("libpolymake_julia_jll")
     write(io, """
-              [$(uuid.uuid)]
+              [$(pkgid.uuid)]
               libpolymake_julia = "$(joinpath(pwd(),"test","install"))"
               """)
 end;


### PR DESCRIPTION
use `Base.identify_package` for that.

this pr only affects the github actions (workflow + `test-prepare.jl` script)