### PR TITLE
add Project.toml and test directory

### DIFF
--- a/.github/workflows/test-polymake.yml
+++ b/.github/workflows/test-polymake.yml
@@ -50,26 +50,19 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
       - name: "pin libcxxwrap_julia"
-        run: julia --project=test/ -e 'using Pkg;
-                                       pkg"add libcxxwrap_julia_jll${{ matrix.libcxxwrap }}";
-                                       pkg"pin libcxxwrap_julia_jll";'
-      - name: "Add polymake packages"
-        run: julia --project=test/ -e 'using Pkg;
-                                       pkg"add polymake_jll";
-                                       pkg"add libpolymake_julia_jll";'
-      - name: "Prepare and set override"
+        run: julia --project=. -e 'using Pkg;
+                                   pkg"instantiate";
+                                   pkg"pin libcxxwrap_julia_jll${{ matrix.libcxxwrap }}";'
+      - name: "Build and set override"
         run: |
-          rm -f ~/.julia/artifacts/Overrides.toml
-          julia --project=test/ test-prepare.jl
-      - name: "Build and install"
-        run: VERBOSE=ON cmake --build build --config Release --target install -- -j2
+          julia --project=. test-prepare.jl --override --build
       - name: "Work around glibcxx issue"
         if: matrix.os == 'ubuntu-20.04'
         run: echo ::set-env name=LD_PRELOAD::/usr/lib/x86_64-linux-gnu/libstdc++.so.6
       - name: "Test polymake"
         env:
            TERM: linux
-        run: julia --project=test/ -e 'using libpolymake_julia_jll;
-                                       polymake_run_script() do exe
-                                          run(`$exe test/run_testcases`);
-                                       end'
+        run: julia --project=. -e 'using libpolymake_julia_jll;
+                                   polymake_run_script() do exe
+                                       run(`$exe test/run_testcases`);
+                                   end'

--- a/.github/workflows/test-polymakejl-branch.yml
+++ b/.github/workflows/test-polymakejl-branch.yml
@@ -55,33 +55,26 @@ jobs:
         # developers affected by this will need to build libcxxwrap-julia manually as well
         run: echo "::set-env name=DEVELOPER_DIR::/Applications/Xcode_11.3.1.app/Contents/Developer"
       - name: "pin libcxxwrap_julia"
-        run: julia --project=test/ -e 'using Pkg;
-                                       pkg"add libcxxwrap_julia_jll${{ matrix.libcxxwrap }}";
-                                       pkg"pin libcxxwrap_julia_jll";'
-      - name: "Add polymake packages"
-        run: julia --project=test/ -e 'using Pkg;
-                                       pkg"add polymake_jll";
-                                       pkg"add libpolymake_julia_jll";'
-      - name: "Prepare and set override"
+        run: julia --project=. -e 'using Pkg;
+                                   pkg"instantiate";
+                                   pkg"pin libcxxwrap_julia_jll${{ matrix.libcxxwrap }}";'
+      - name: "Build and set override"
         run: |
-          rm -f ~/.julia/artifacts/Overrides.toml
-          julia --project=test/ test-prepare.jl
-      - name: "Build and install"
-        run: VERBOSE=ON cmake --build build --config Release --target install -- -j2
+          julia --project=. test-prepare.jl --override --build
       - name: "Look for Polymake.jl branch"
         id: detectbranch
         # look for a branch with the same name for Polymake.jl
         continue-on-error: true
-        run: julia --project=test/ -e "using Pkg;
-                                       pkg\"add Polymake#${GITHUB_HEAD_REF#refs/heads/}\";"
+        run: julia --project=. -e "using Pkg;
+                                   pkg\"add Polymake#${GITHUB_HEAD_REF#refs/heads/}\";"
       - name: "Test Polymake.jl master"
         # use master otherwise
         if: steps.detectbranch.outcome == 'failure'
-        run: julia --project=test/ -e 'using Pkg;
-                                       pkg"add Polymake#master";'
+        run: julia --project=. -e 'using Pkg;
+                                   pkg"add Polymake#master";'
       - name: "Work around glibcxx issue"
         if: matrix.os == 'ubuntu-20.04'
         run: echo ::set-env name=LD_PRELOAD::/usr/lib/x86_64-linux-gnu/libstdc++.so.6
       - name: "Test Polymake.jl branch"
-        run: julia --project=test/ -e 'using Pkg;
-                                       pkg"test Polymake";'
+        run: julia --project=. -e 'using Pkg;
+                                   pkg"test Polymake";'

--- a/.github/workflows/test-polymakejl-release.yml
+++ b/.github/workflows/test-polymakejl-release.yml
@@ -55,24 +55,17 @@ jobs:
         # developers affected by this will need to build libcxxwrap-julia manually as well
         run: echo "::set-env name=DEVELOPER_DIR::/Applications/Xcode_11.3.1.app/Contents/Developer"
       - name: "pin libcxxwrap_julia"
-        run: julia --project=test/ -e 'using Pkg;
-                                       pkg"add libcxxwrap_julia_jll${{ matrix.libcxxwrap }}";
-                                       pkg"pin libcxxwrap_julia_jll";'
-      - name: "Add polymake packages"
-        run: julia --project=test/ -e 'using Pkg;
-                                       pkg"add polymake_jll";
-                                       pkg"add libpolymake_julia_jll";'
-      - name: "Prepare and set override"
+        run: julia --project=. -e 'using Pkg;
+                                   pkg"instantiate";
+                                   pkg"pin libcxxwrap_julia_jll${{ matrix.libcxxwrap }}";'
+      - name: "Build and set override"
         run: |
-          rm -f ~/.julia/artifacts/Overrides.toml
-          julia --project=test/ test-prepare.jl
-      - name: "Build and install"
-        run: VERBOSE=ON cmake --build build --config Release --target install -- -j2
+          julia --project=. test-prepare.jl --override --build
       - name: "Work around glibcxx issue"
         if: matrix.os == 'ubuntu-20.04'
         run: echo ::set-env name=LD_PRELOAD::/usr/lib/x86_64-linux-gnu/libstdc++.so.6
       - name: "Test Polymake.jl release"
         # TODO: this will fail until 0.5 is released
-        run: julia --project=test/ -e 'using Pkg;
-                                       pkg"add Polymake";
-                                       pkg"test Polymake";'
+        run: julia --project=. -e 'using Pkg;
+                                   pkg"add Polymake";
+                                   pkg"test Polymake";'

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ CMakeFiles/*
 Makefile
 generated/*
 build/*
-test/*

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,4 @@
+[deps]
+libcxxwrap_julia_jll = "3eaa8342-bff7-56a5-9981-c04077f7cee7"
+libpolymake_julia_jll = "4d8266f6-2b3b-57e3-ad7a-d431eaaac945"
+polymake_jll = "7c209550-9012-526c-9264-55ba7a78ba2c"

--- a/README.md
+++ b/README.md
@@ -39,3 +39,16 @@ polymake = "/home/user/path/to/polymake"
 [3eaa8342-bff7-56a5-9981-c04077f7cee7]
 libcxxwrap_julia = "/home/user/path/to/libcxxwrap-julia"
 ```
+
+### Convenience script
+
+For convenience we provide `test-prepare.jl` script which can be used to compile and place overrides at once.
+First execute
+```julia
+julia --project test-prepare.jl
+```
+If the compilation succeeds and the displayed overrides seem correct run
+```julia
+julia --project test-prepare.jl --override
+```
+

--- a/test-prepare.jl
+++ b/test-prepare.jl
@@ -3,6 +3,13 @@ using polymake_jll
 using libcxxwrap_julia_jll
 
 # we need to adjust the test-driver to running from the callable library
+let file = joinpath("test","run_testcases")
+    if !isfile(file)
+        mkpath(dirname(file))
+        touch(file)
+    end
+end
+
 open(joinpath("test","run_testcases"), write=true) do out
     open(joinpath(polymake_jll.artifact_dir,"share","polymake","scripts","run_testcases")) do in
         for line in eachline(in, keep=true) # keep so the new line isn't chomped
@@ -44,4 +51,8 @@ let file = joinpath(Pkg.depots1(),"artifacts","Overrides.toml")
         write(file, join(lines, "\n"))
         @info "$file written."
     end
+end
+
+if "--build" in ARGS
+    run(`cmake --build build --config Release --target install -- -j2`)
 end

--- a/test-prepare.jl
+++ b/test-prepare.jl
@@ -25,6 +25,10 @@ run(`cmake \
 # add override
 
 let file = joinpath(Pkg.depots1(),"artifacts","Overrides.toml")
+    if !isfile(file)
+        mkpath(dirname(file))
+        touch(file)
+    end
     lines = readlines(file)
     pkgid = Base.identify_package("libpolymake_julia_jll")
     k = findfirst(==("[$(pkgid.uuid)]"), lines)
@@ -34,5 +38,10 @@ let file = joinpath(Pkg.depots1(),"artifacts","Overrides.toml")
     else
         append!(lines, ["[$(pkgid.uuid)]", "libpolymake_julia = \"$(joinpath(pwd(),"test","install"))\""])
     end
-    write(file, join(lines, "\n"))
+    if !("--override" in ARGS)
+        @info "$file to be written:\n$(join(lines, "\n"))\nTo actually write the file run julia --project test-prepare.jl --override"
+    else
+        write(file, join(lines, "\n"))
+        @info "$file written."
+    end
 end

--- a/test-prepare.jl
+++ b/test-prepare.jl
@@ -23,11 +23,16 @@ run(`cmake \
      -S . -B build`);
 
 # add override
-open("$(joinpath(Pkg.depots1(),"artifacts","Overrides.toml"))", "a") do io
-    pkgid = Base.identify_package("libpolymake_julia_jll")
-    write(io, """
-              [$(pkgid.uuid)]
-              libpolymake_julia = "$(joinpath(pwd(),"test","install"))"
-              """)
-end;
 
+let file = joinpath(Pkg.depots1(),"artifacts","Overrides.toml")
+    lines = readlines(file)
+    pkgid = Base.identify_package("libpolymake_julia_jll")
+    k = findfirst(==("[$(pkgid.uuid)]"), lines)
+    if !isnothing(k)
+        @assert k < length(lines) "Overrides.toml seem to be ill formatted"
+        lines[k+1] = "libpolymake_julia = \"$(joinpath(pwd(),"test","install"))\""
+    else
+        append!(lines, ["[$(pkgid.uuid)]", "libpolymake_julia = \"$(joinpath(pwd(),"test","install"))\""])
+    end
+    write(file, join(lines, "\n"))
+end

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,1 @@
+run_testcases


### PR DESCRIPTION
you need to `instantiate` the env and run `julia --project test-prepare.jl` now (for dry run), or `julia --project test-prepare.jl --override`. e.x.:

```
$ julia --project test-prepare.jl
-- Found Julia executable: /opt/bin/julia
-- Julia_VERSION_STRING: 1.5.2
[...]
-- Generating done
-- Build files have been written to: /home/kalmar/local/src/libpolymake-julia/build
┌ Info: Overrides.toml to be written:
│ [4d8266f6-2b3b-57e3-ad7a-d431eaaac945]
│ libpolymake_julia = "/home/kalmar/local/src/libpolymake-julia/test/install"
└ To actually write the file run julia --project test-prepare --override
```
