### PR TITLE
copy for bigobject, polymake Scopes for prefer_now

### DIFF
--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -14,8 +14,6 @@ void initialize_polymake(bool interactive = true)
         if (data.main_polymake_session == nullptr) {
             data.main_polymake_session = new polymake::Main;
             data.main_polymake_session->shell_enable();
-            data.main_polymake_scope = new polymake::Scope(
-                data.main_polymake_session->newScope());
             if (interactive){
                 std::cout << data.main_polymake_session->greeting() << std::endl;
             };

--- a/src/jlpolymake.cpp
+++ b/src/jlpolymake.cpp
@@ -102,8 +102,27 @@ JLCXX_MODULE define_module_polymake(jlcxx::Module& jlpolymake)
         return ctx_help;
     });
 
+    jlpolymake.add_type<polymake::Scope>("Scope_internal");
+    jlpolymake.add_type<std::optional<polymake::Scope>>("Scope");
+
     jlpolymake.method("set_preference", [](const std::string x) {
         return data.main_polymake_session->set_preference(x);
+    });
+
+    jlpolymake.method("scope_begin", []() {
+        return std::optional<polymake::Scope>(
+                // allocate new scope object
+                std::move(data.main_polymake_session->newScope())
+            );
+    });
+    jlpolymake.method("scope_end", [](std::optional<polymake::Scope>& scope) {
+        // destroy scope object to force immediate reset of any temporary changes
+        scope.reset();
+    });
+    jlpolymake.method("internal_prefer_now", [](const std::optional<polymake::Scope>& scope, const std::string& label) {
+        if (!scope)
+           throw std::runtime_error("attempt to use polymake::Scope after destruction");
+        scope->prefer_now(label);
     });
 
 #include "jlpolymake/generated/map_inserts.h"

--- a/src/type_bigobjects.cpp
+++ b/src/type_bigobjects.cpp
@@ -27,11 +27,14 @@ void add_bigobject(jlcxx::Module& jlpolymake)
 
     jlpolymake.add_type<pm::perl::BigObjectType>("BigObjectType")
         .constructor<const std::string&>()
-        .method("type_name", [](pm::perl::BigObjectType p) { return p.name(); });
+        .method("type_name", [](const pm::perl::BigObjectType& p) { return p.name(); });
 
     jlpolymake.add_type<pm::perl::BigObject>("BigObject")
         .constructor<const pm::perl::BigObjectType&>()
         .constructor<const pm::perl::BigObjectType&, const pm::perl::BigObject&>()
+        .method("internal_copy", [](const pm::perl::BigObject& p) {
+                    return p.copy();
+                })
         .method("save_bigobject",
                 [](const pm::perl::BigObject& p, const std::string& s) {
                     return p.save(s);


### PR DESCRIPTION
~~Failures for Polymake.jl release are expected as this bumps the version of `libpolymake_julia` which the release doesn't accept.~~
this should be backwards compatible, tests do succeed with the polymake.jl release.