### PR TITLE
Adapt for julia 1.7

### DIFF
--- a/.github/workflows/test-polymake.yml
+++ b/.github/workflows/test-polymake.yml
@@ -15,13 +15,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        julia-version: ['1.5', 'nightly']
+        julia-version: ['1.5', '~1.6.0-0', 'nightly']
         libcxxwrap: [ '' ]
         include:
           - os: ubuntu-latest
-            julia-version: '~1.6.0-0'
+            julia-version: '~1.7.0-0'
           - os: macOS-11.0
-            julia-version: '~1.6.0-0'
+            julia-version: '~1.7.0-0'
           - os: macOS-latest
             julia-version: 1.4
           - libcxxwrap: '@0.7'

--- a/.github/workflows/test-polymakejl-branch.yml
+++ b/.github/workflows/test-polymakejl-branch.yml
@@ -15,13 +15,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        julia-version: ['1.5', 'nightly']
+        julia-version: ['1.5', '~1.6.0-0', 'nightly']
         libcxxwrap: [ '' ]
         include:
           - os: ubuntu-latest
-            julia-version: '~1.6.0-0'
+            julia-version: '~1.7.0-0'
           - os: macOS-11.0
-            julia-version: '~1.6.0-0'
+            julia-version: '~1.7.0-0'
           - os: macOS-latest
             julia-version: 1.4
           - libcxxwrap: '@0.7'

--- a/.github/workflows/test-polymakejl-release.yml
+++ b/.github/workflows/test-polymakejl-release.yml
@@ -15,13 +15,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        julia-version: ['1.5', 'nightly']
+        julia-version: ['1.5', '~1.6.0-0', 'nightly']
         libcxxwrap: [ '' ]
         include:
           - os: ubuntu-latest
-            julia-version: '~1.6.0-0'
+            julia-version: '~1.7.0-0'
           - os: macOS-11.0
-            julia-version: '~1.6.0-0'
+            julia-version: '~1.7.0-0'
           - os: macOS-latest
             julia-version: 1.4
           - libcxxwrap: '@0.7'

--- a/src/type_lists.cpp
+++ b/src/type_lists.cpp
@@ -12,7 +12,7 @@ void add_lists(jlcxx::Module& jlpolymake)
 {
     auto type = jlpolymake
         .add_type<jlcxx::Parametric<jlcxx::TypeVar<1>>>(
-            "StdList", jlcxx::julia_type("Any", "Base"));
+            "StdList");
 
         type.apply<std::list<std::pair<pm::Int,pm::Int>>>([&jlpolymake](auto wrapped) {
             typedef typename decltype(wrapped)::type WrappedT;

--- a/src/type_pairs.cpp
+++ b/src/type_pairs.cpp
@@ -13,7 +13,7 @@ void add_pairs(jlcxx::Module& jlpolymake)
 
     auto type = jlpolymake
         .add_type<jlcxx::Parametric<jlcxx::TypeVar<1>, jlcxx::TypeVar<2>>>(
-            "StdPair", jlcxx::julia_type("Any", "Base" ));
+            "StdPair");
 
         type.apply<std::pair<pm::Int,pm::Int>>([&jlpolymake](auto wrapped) {
             typedef typename decltype(wrapped)::type WrappedT;

--- a/src/type_polynomial.cpp
+++ b/src/type_polynomial.cpp
@@ -12,7 +12,7 @@ void add_polynomial(jlcxx::Module& jlpolymake)
 {
     jlpolymake
         .add_type<jlcxx::Parametric<jlcxx::TypeVar<1>, jlcxx::TypeVar<2>>>(
-            "Polynomial", jlcxx::julia_type("Any", "Base"))
+            "Polynomial")
         .apply_combination<pm::Polynomial, VecOrMat_supported::value_type, jlcxx::ParameterList<pm::Int>>(
             [](auto wrapped) {
                 typedef typename decltype(wrapped)::type polyT;


### PR DESCRIPTION
Subtyping from `Base.Any` produces errors on julia 1.7, lets see if this is also fine with older julia versions.
Also test with 1.7 and try the new libcxxwrap binaries.