### PR TITLE
Fix comparison rational int64

### DIFF
--- a/src/type_rationals.cpp
+++ b/src/type_rationals.cpp
@@ -76,7 +76,7 @@ void add_rational(jlcxx::Module& jlpolymake)
         jlpolymake.method("==", [](pm::Rational& a, int64_t b) {
             return a == static_cast<pm::Int>(b); });
         jlpolymake.method("==", [](int64_t a, pm::Rational& b) {
-        return static_cast<pm::Int>(a) == b; });
+            return static_cast<pm::Int>(a) == b; });
         // the symmetric definitions are on the julia side
         jlpolymake.method("+", [](pm::Rational& a, pm::Rational& b) {
             return a + b; });

--- a/src/type_rationals.cpp
+++ b/src/type_rationals.cpp
@@ -74,9 +74,9 @@ void add_rational(jlcxx::Module& jlpolymake)
         jlpolymake.method("==", [](pm::Integer& a, pm::Rational& b) {
             return a == b; });
         jlpolymake.method("==", [](pm::Rational& a, int64_t b) {
-            return static_cast<pm::Int>(a) == b; });
-        jlpolymake.method("==", [](int64_t a, pm::Rational& b) {
             return a == static_cast<pm::Int>(b); });
+        jlpolymake.method("==", [](int64_t a, pm::Rational& b) {
+        return static_cast<pm::Int>(a) == b; });
         // the symmetric definitions are on the julia side
         jlpolymake.method("+", [](pm::Rational& a, pm::Rational& b) {
             return a + b; });


### PR DESCRIPTION
Fix for wrong cast when comparing `Rational` and `Int64` which lead to an error when taking a non-integer `Rational`.