### PR TITLE
CI: update some actions to latest versions

### DIFF
--- a/.github/workflows/test-oscar.yml
+++ b/.github/workflows/test-oscar.yml
@@ -23,7 +23,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       JULIA_PKG_SERVER: ""
     steps:
-    - uses: actions/checkout@v2.1.0
+    - uses: actions/checkout@v3
     - name: "Set up Julia"
       uses: julia-actions/setup-julia@v1
       with:
@@ -64,7 +64,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2.1.0
+      - uses: actions/checkout@v3
       - name: "Set up Julia"
         uses: julia-actions/setup-julia@v1
         with:

--- a/.github/workflows/test-polymake.yml
+++ b/.github/workflows/test-polymake.yml
@@ -36,9 +36,9 @@ jobs:
       fail-fast: true
 
     steps:
-      - uses: actions/checkout@v2.1.0
+      - uses: actions/checkout@v3
       - name: Cache artifacts
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-artifacts
         with:


### PR DESCRIPTION
GitHub warns that this is needed because they are updating from Node 12 to 16
