### PR TITLE
Improve performance for conversions between common types

### DIFF
--- a/src/type_integer.cpp
+++ b/src/type_integer.cpp
@@ -56,7 +56,6 @@ pm::Integer new_integer_from_fmpq(jl_value_t* rational)
 
 pm::Int new_int_from_integer(const pm::Integer& integer)
 {
-    if (isinf(integer)) throw pm::GMP::BadCast();
     return static_cast<pm::Int>(integer);
 }
 
@@ -83,6 +82,7 @@ void add_integer(jlcxx::Module& jlpolymake)
                 [](pm::Integer& i) {
                     return show_small_object<pm::Integer>(i, false);
                 })
+        .method("isfinite", [](const pm::Integer& i) { return isfinite(i); })
         .method("Float64", [](pm::Integer& a) { return double(a); })
         .method("-", [](pm::Integer& a, pm::Integer& b) { return a - b; })
         .method("-", [](pm::Integer& a,

--- a/src/type_rational.cpp
+++ b/src/type_rational.cpp
@@ -39,14 +39,13 @@ void new_fmpz_from_rational(const pm::Rational& rational, void* p_fmpz)
 
 pm::Int new_int_from_rational(const pm::Rational& rational)
 {
-    if (!rational.is_integral() || isinf(rational)) throw pm::GMP::BadCast();
     return static_cast<pm::Int>(rational);
 }
 
 pm::Integer new_integer_from_rational(const pm::Rational& rational)
 {
     if (!rational.is_integral()) throw pm::GMP::BadCast();
-    return static_cast<pm::Integer>(rational);
+    return numerator(rational);
 }
 
 pm::Rational new_rational_from_integer(const pm::Integer& integer)
@@ -105,6 +104,7 @@ void add_rational(jlcxx::Module& jlpolymake)
                 [](const pm::Rational& r) {
                     return show_small_object<pm::Rational>(r, false);
                 })
+        .method("isfinite", [](const pm::Rational& r) { return isfinite(r); })
         .method("Float64", [](pm::Rational& a) { return double(a); })
         .method("-", [](pm::Rational& a, pm::Rational& b) { return a - b; })
         .method("-", [](pm::Rational& a, pm::Integer& b) { return a - b; })


### PR DESCRIPTION
Cross-repository changes which reduce allocations for conversions:

As of creation of this PR this includes:
* `Polymake.Integer` <-> `Polymake.Rational`
* `Polymake.Rational`/`Polymake.Integer` -> `Int64` (`CxxLong`)
* `Polymake.Integer` -> `BigInt` (used as fallback for conversions)
* `Polymake.Rational` <-> `Base.Rational{BigInt}` (used as fallback for conversions)