### PR TITLE
apps-json: make sure to load all apps first

### DIFF
--- a/src/polymake/apptojson.pl
+++ b/src/polymake/apptojson.pl
@@ -187,6 +187,10 @@ sub app_to_json($$) {
    close $F;
 }
 
+# make sure to load all apps before generating the json files to avoid skipping
+# cross-application rule sections
+map { application($_) } @apps;
+
 foreach my $app (@apps) {
    app_to_json($jsonpath,$app);
 }


### PR DESCRIPTION
cc: @alexej-jordan 

With this change:
```
sandbox:${WORKSPACE}/srcdir # grep bracket_ideal $jsondir/*
/workspace/destdir/share/libpolymake_julia/appsjson//ideal.json:      "doc" : "bracket_ideal_pluecker(m) -> Ideal\n\n Generates the ideal of all Grassmann-Plücker relations of the given matroid.\n For the algorithm see Sturmfels: Algorithms in invariant theory, Springer, 2nd ed., 2008\n\nArguments:\n  matroid::Matroid m \n\nReturns Ideal the Grassmann-Plücker ideal\n",
/workspace/destdir/share/libpolymake_julia/appsjson//ideal.json:      "name" : "bracket_ideal_pluecker",
```
(Without it that grep returns nothing)